### PR TITLE
Stopped workflows to run on push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Build and Test the Software Stack
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
## Brief Description
workflows: stopped workflows to run on push

## Details
Removed unecessary execution of workflows on push. Should only be executed on PRs for checks.

## Tasks

- [x] Tests written/updated and implemented to CI
