### PR TITLE
Sensor bringup impl

### DIFF
--- a/src/amp_kart_bringup/README.md
+++ b/src/amp_kart_bringup/README.md
@@ -6,6 +6,7 @@ Contains files needed to start the kart.
 
 - `launch/`
   - `bringup.launch.py` _Start the high-level navigation software stack_
+  - `kart.launch.py` _Start sensors and micro ros_
   - `localization.launch.py` _Initialize map_server and amcl_
   - `navigation.launch.py` _Initialize Nav2_
   - `rviz.launch.py` _Initialize RViz with Nav2 configuration_

--- a/src/amp_kart_bringup/launch/kart.launch.py
+++ b/src/amp_kart_bringup/launch/kart.launch.py
@@ -16,7 +16,7 @@ def generate_launch_description():
     bringup_share_dir = get_package_share_directory('amp_kart_bringup')
     zed_wrapper_share_dir = get_package_share_directory('zed_wrapper')
     share_path = get_package_share_directory('amp_kart_description')
-    model_path = os.path.join(share_path, 'urdf', 'kart.urdf')
+    model_path = os.path.join(share_path, 'urdf', 'racecar.xacro')
 
     robot_description = ParameterValue(xacro.process_file(
         str(model_path)).toprettyxml(indent='  '),

--- a/src/amp_kart_bringup/launch/kart.launch.py
+++ b/src/amp_kart_bringup/launch/kart.launch.py
@@ -3,7 +3,8 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import (GroupAction, IncludeLaunchDescription)
+from launch.actions import (DeclareLaunchArgument, GroupAction,
+                            IncludeLaunchDescription)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 from launch_ros.actions import Node
@@ -17,6 +18,13 @@ def generate_launch_description():
     zed_wrapper_share_dir = get_package_share_directory('zed_wrapper')
     share_path = get_package_share_directory('amp_kart_description')
     model_path = os.path.join(share_path, 'urdf', 'racecar.xacro')
+
+    micro_ros_agent_node = Node(
+        package='micro_ros_agent',
+        executable='micro_ros_agent',
+        name='micro_ros_agent',
+        arguments=['serial', '--dev',
+                   LaunchConfiguration('serial_tty')])
 
     robot_description = ParameterValue(xacro.process_file(
         str(model_path)).toprettyxml(indent='  '),
@@ -41,6 +49,12 @@ def generate_launch_description():
 
     ld = LaunchDescription()
 
+    ld.add_action(
+        DeclareLaunchArgument(name='seria_tty',
+                              default_value='/dev/ttyUSB0',
+                              description='Serial TTY absolute file location'))
+
+    ld.add_action(micro_ros_agent_node)
     ld.add_action(robot_state_publisher_node)
     ld.add_action(sensor_launch_group)
 

--- a/src/amp_kart_bringup/launch/kart.launch.py
+++ b/src/amp_kart_bringup/launch/kart.launch.py
@@ -1,0 +1,47 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import (GroupAction, IncludeLaunchDescription)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+import xacro
+
+
+def generate_launch_description():
+    bringup_share_dir = get_package_share_directory('amp_kart_bringup')
+    zed_wrapper_share_dir = get_package_share_directory('zed_wrapper')
+    share_path = get_package_share_directory('amp_kart_description')
+    model_path = os.path.join(share_path, 'urdf', 'kart.urdf')
+
+    robot_description = ParameterValue(xacro.process_file(
+        str(model_path)).toprettyxml(indent='  '),
+                                       value_type=str)
+
+    robot_state_publisher_node = Node(package='robot_state_publisher',
+                                      executable='robot_state_publisher',
+                                      parameters=[{
+                                          'robot_description':
+                                          robot_description
+                                      }])
+
+    sensor_launch_group = GroupAction([
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(bringup_share_dir, 'launch', 'VLP16.launch.py'))),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(zed_wrapper_share_dir, 'launch',
+                             'zed.launch.py'))),
+    ])
+
+    ld = LaunchDescription()
+
+    ld.add_action(robot_state_publisher_node)
+    ld.add_action(sensor_launch_group)
+
+    return ld


### PR DESCRIPTION
## Brief Description
Created a launch file that launches the two sensors of the kart, VLP16 and zed camera, and the robot state publisher node. The sensors publish data for the navigation and the robot state publisher publishes the state of the robot (kart).
## Tasks

- [ ] Updated Documentation
kart.bringup.launch.py - launches VLP16 sensor, zed camera, and robot state publisher node.
