### PR TITLE
add modules and fix slam_toolbox

### DIFF
--- a/src/amp_kart_bringup/launch/kart.launch.py
+++ b/src/amp_kart_bringup/launch/kart.launch.py
@@ -47,12 +47,11 @@ def generate_launch_description():
                 os.path.join(bringup_share_dir, 'launch', 'zed.launch.py'))),
     ])
 
-    pointcloud_to_laserscan_node = Node(package='pointcloud_to_laserscan',
-                                        executable='pointcloud_to_laserscan',
-                                        remappings=[
-                                            ('scan', 'flattened_pointcloud'),
-                                            ('cloud_in', 'velodyne_points')
-                                        ])
+    pointcloud_to_laserscan_node = Node(
+        package='pointcloud_to_laserscan',
+        executable='pointcloud_to_laserscan_node',
+        remappings=[('scan', 'flattened_pointcloud'),
+                    ('cloud_in', 'velodyne_points')])
 
     ld = LaunchDescription()
 
@@ -64,5 +63,6 @@ def generate_launch_description():
     ld.add_action(micro_ros_agent_node)
     ld.add_action(robot_state_publisher_node)
     ld.add_action(sensor_launch_group)
+    ld.add_action(pointcloud_to_laserscan_node)
 
     return ld

--- a/src/amp_kart_bringup/launch/kart.launch.py
+++ b/src/amp_kart_bringup/launch/kart.launch.py
@@ -47,6 +47,13 @@ def generate_launch_description():
                 os.path.join(bringup_share_dir, 'launch', 'zed.launch.py'))),
     ])
 
+    pointcloud_to_laserscan_node = Node(package='pointcloud_to_laserscan',
+                                        executable='pointcloud_to_laserscan',
+                                        remappings=[
+                                            ('scan', 'flattened_pointcloud'),
+                                            ('cloud_in', 'velodyne_points')
+                                        ])
+
     ld = LaunchDescription()
 
     ld.add_action(

--- a/src/amp_kart_bringup/package.xml
+++ b/src/amp_kart_bringup/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>velodyne_msgs</exec_depend>
   <exec_depend>velodyne_pointcloud</exec_depend>
   <exec_depend>spatio_temporal_voxel_layer</exec_depend>
+  <exec_depend>pointcloud_to_laserscan</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/amp_kart_bringup/params/nav2.params.yaml
+++ b/src/amp_kart_bringup/params/nav2.params.yaml
@@ -37,7 +37,7 @@ amcl:
     z_max: 0.05
     z_rand: 0.5
     z_short: 0.05
-    scan_topic: scan
+    scan_topic: flattened_pointcloud
 
 amcl_map_client:
   ros__parameters:
@@ -356,7 +356,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_link
-    scan_topic: /scan
+    scan_topic: /flattened_pointcloud
     mode: mapping #localization
 
     # if you'd like to immediately start continuing a map at a given pose

--- a/src/amp_kart_bringup/params/nav2.params.yaml
+++ b/src/amp_kart_bringup/params/nav2.params.yaml
@@ -221,7 +221,11 @@ global_costmap:
       plugins: ["static_layer", "stvl_layer", "inflation_layer"]
       static_layer:
         plugin: "nav2_costmap_2d::StaticLayer"
-        map_subscribe_transient_local: True
+        enabled: true
+        subscribe_to_updates: true
+        map_subscribe_transient_local: false
+        transform_tolerance: 0.0
+        map_topic: "/map"
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0
@@ -371,7 +375,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
-    max_laser_range: 20.0 #for rastering images
+    max_laser_range: 100.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2
     tf_buffer_duration: 30.


### PR DESCRIPTION
## Brief Description

Takes in the pointcloud from the lidar and converts into a 2D laserscan. Flattened pointcloud is then fed into `slam_toolbox`. Also fixed issue where global costmap was not properly setup to subscribe to `/map`.